### PR TITLE
fix: add `networking.k8s.io` to traefik rbac

### DIFF
--- a/k8s/traefik/rbac.yaml
+++ b/k8s/traefik/rbac.yaml
@@ -23,6 +23,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:


### PR DESCRIPTION
to support the changes to the nginx ingress object, traefik needs access to the updated apiGroup.

Thanks for building this repo, it has been a great help!
