### PR TITLE
include ingressclasses in the resources list

### DIFF
--- a/k8s-ingress/traefik/rbac.yaml
+++ b/k8s-ingress/traefik/rbac.yaml
@@ -26,6 +26,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list


### PR DESCRIPTION
Was getting:
```
E0316 00:49:21.414853       1 reflector.go:140] k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: Failed to watch *v1.IngressClass: failed to list *v1.IngressClass: ingressclasses.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:traefik-ingress-controller" cannot list resource "ingressclasses" in API group "networking.k8s.io" at the cluster scope
```